### PR TITLE
Finalized photo support for workers and proposed jobs

### DIFF
--- a/web/lib/api/fileManager.ts
+++ b/web/lib/api/fileManager.ts
@@ -28,6 +28,7 @@ export const renameFile = async (
 
 export const updatePhotoPathByNewFilename = (
   originalPath: string,
+  lastDirectory: string,
   newFilename: string
 ): string | undefined => {
   const lastSlashIndex = originalPath.lastIndexOf('/')
@@ -39,11 +40,11 @@ export const updatePhotoPathByNewFilename = (
   }
 
   // get part before and after replaced part
-  const directory = originalPath.slice(0, lastSlashIndex + 1) // directory part
+  const directory = originalPath.slice(0, lastSlashIndex) // directory part
   const fileType = originalPath.slice(lastDotIndex) // type part
 
   // create new path
-  return `${directory}${newFilename}${fileType}`
+  return `${directory}${lastDirectory}/${newFilename}${fileType}`
 } 
 
 export const createDirectory = async (dirName: string) => {
@@ -52,5 +53,14 @@ export const createDirectory = async (dirName: string) => {
   }
   catch (error) {
     await promises.mkdir(dirName)
+  }
+}
+
+export const deleteDirectory = async (dirName: string) => {
+  try {
+    await promises.access(dirName)
+    await promises.rmdir(dirName)
+  }
+  catch (error) {
   }
 }

--- a/web/lib/api/registerPhotos.ts
+++ b/web/lib/api/registerPhotos.ts
@@ -7,7 +7,7 @@ export const registerPhotos = async (files: formidable.Files): Promise<string[]>
   const newPhotoIds: string[] = []
   // Go through every file in files
   const fileFieldNames = Object.keys(files)
-  fileFieldNames.forEach(async fieldName => { 
+  for (const fieldName of fileFieldNames) {
     const file = files[fieldName]
     const photoPath = getPhotoPath(file)
     const photo = {photoPath: photoPath}
@@ -19,6 +19,6 @@ export const registerPhotos = async (files: formidable.Files): Promise<string[]>
     const newPhotoPath = updatePhotoPathByNewFilename(photoPath, newPhoto.id) ?? ''
     renameFile(photoPath, newPhotoPath)
     await updatePhoto(newPhoto.id, {photoPath: newPhotoPath})
-  })
+  }
   return newPhotoIds
 }

--- a/web/lib/api/registerPhotos.ts
+++ b/web/lib/api/registerPhotos.ts
@@ -3,7 +3,7 @@ import { getPhotoPath } from "./parse-form"
 import { createPhoto, updatePhoto } from "lib/data/photo"
 import { updatePhotoPathByNewFilename, renameFile } from "./fileManager"
 
-export const registerPhotos = async (files: formidable.Files): Promise<string[]> => {
+export const registerPhotos = async (files: formidable.Files, lastDirectory: string): Promise<string[]> => {
   const newPhotoIds: string[] = []
   // Go through every file in files
   const fileFieldNames = Object.keys(files)
@@ -16,7 +16,7 @@ export const registerPhotos = async (files: formidable.Files): Promise<string[]>
     // save its id to photoIds array
     newPhotoIds.push(newPhoto.id)
     // rename photo to its id instead of temporary name which was proposedJob.id-number given in parseFormWithImages
-    const newPhotoPath = updatePhotoPathByNewFilename(photoPath, newPhoto.id) ?? ''
+    const newPhotoPath = updatePhotoPathByNewFilename(photoPath, lastDirectory, newPhoto.id) ?? ''
     renameFile(photoPath, newPhotoPath)
     await updatePhoto(newPhoto.id, {photoPath: newPhotoPath})
   }

--- a/web/lib/components/forms/ImageUploader.tsx
+++ b/web/lib/components/forms/ImageUploader.tsx
@@ -6,6 +6,7 @@ import React from 'react'
 import FormWarning from './FormWarning'
 import PhotoModal from 'lib/components/modal/PhotoModal'
 import { customErrorMessages as err } from 'lib/lang/error-messages'
+import Link from 'next/link'
 
 interface PreviewUrl {
   url: string
@@ -127,11 +128,14 @@ export const ImageUploader = <FormData extends FieldValues> ({
                       </button>
                     </div>
                   </div>
-                  <div className="d-flex justify-content-center align-items-center">
+                  <div
+                    className="d-inline-flex gap-2 flex-wrap align-items-center">
                     <div
-                      className="cursor-pointer smj-photo-size"
+                      className="smj-photo-size"
                       style={{ 
-                        position: 'relative'}}
+                        position: 'relative',
+                        cursor: 'zoom-in'  
+                      }}
                     >
                       <Image
                         className="responsive"
@@ -143,6 +147,11 @@ export const ImageUploader = <FormData extends FieldValues> ({
                         loading="eager"
                         priority  
                         onClick={() => openPhotoModal(index)}
+                        onMouseDown={(e) => { // open image in new tab with middle mouse click
+                          if( e.button === 1 ) {
+                            window.open(url.url)
+                          }
+                        }}
                       />
                     </div>
                   </div>

--- a/web/lib/components/forms/ImageUploader.tsx
+++ b/web/lib/components/forms/ImageUploader.tsx
@@ -101,7 +101,7 @@ export const ImageUploader = <FormData extends FieldValues> ({
           {secondaryLabel}
         </p>
       )}
-      <div className="row mb-2">
+      <div className="row mb-2 smj-file-upload">
         <input
           type="file"
           disabled={previewUrls.length >= maxPhotos}

--- a/web/lib/components/forms/ImageUploader.tsx
+++ b/web/lib/components/forms/ImageUploader.tsx
@@ -5,18 +5,22 @@ import Image from 'next/image'
 import React from 'react'
 import FormWarning from './FormWarning'
 import PhotoModal from 'lib/components/modal/PhotoModal'
-import { calculateDimensions } from 'lib/components/photo/photo'
 import { customErrorMessages as err } from 'lib/lang/error-messages'
+
+interface PreviewUrl {
+  url: string
+  index?: string
+}
 
 interface ImageUploaderProps<FormData extends FieldValues> {
   id: Path<FormData>
   label: string
   secondaryLabel?: string
-  photoInit?: string[] | null
-  setPhotoFileState?: (state: boolean) => void
+  photoInit?: PreviewUrl[] | null
   errors: FieldErrors<FormData>
-  register: UseFormRegister<FormData>
-  removePhoto: (index: number) => void
+  registerPhoto: (fileList: FileList) => void
+  removeExistingPhoto?: (index: string) => void
+  removeNewPhoto: (index: number) => void
   multiple?: boolean
   maxPhotos?: number
   maxFileSize?: number
@@ -27,31 +31,22 @@ export const ImageUploader = <FormData extends FieldValues> ({
   label,
   secondaryLabel,
   photoInit = null,
-  setPhotoFileState,
   errors,
-  register,
-  removePhoto,
+  registerPhoto,
+  removeExistingPhoto,
+  removeNewPhoto,
   multiple = false,
   maxPhotos = 1,
   maxFileSize = 1024*1024*10 // 10 MB
 }: ImageUploaderProps<FormData>) => {
 
   const error = errors?.[id]?.message as string | undefined
-  const [errorBeforeSave, setErrorBeforeSave] = useState<string | undefined>(undefined);
+  const [errorBeforeSave, setErrorBeforeSave] = useState<string | undefined>(undefined)
 
-  const [previewUrls, setPreviewUrls] = useState<(string | null)[]>(photoInit || [])
+  const [photoInitCount, setphotoInitCount] = useState(photoInit?.length ?? 0)
+  const [previewUrls, setPreviewUrls] = useState<(PreviewUrl | null)[]>(photoInit || [])
   const [showPhotoModal, setShowPhotoModal] = useState(false)
-  const [currentPhotoIndex, setCurrentPhotoIndex] = useState(1)
-  const [dimensions, setDimensions] = useState<{ width: number; height: number }[]>([])
-  const [widthOfWindow, setWidthOfWindow] = useState(0)
-
-  const handleResize = () => setWidthOfWindow(window.innerWidth)
-
-  useEffect(() => {
-    handleResize()
-    window.addEventListener('resize', handleResize)
-    return () => window.removeEventListener('resize', handleResize)
-  }, [])
+  const [currentPhotoIndex, setCurrentPhotoIndex] = useState(0)
 
   const onFileUploadChange = (e: ChangeEvent<HTMLInputElement>) => {
     setErrorBeforeSave(undefined)
@@ -69,35 +64,30 @@ export const ImageUploader = <FormData extends FieldValues> ({
       if (!file.type.startsWith('image') || file.size > maxFileSize) {
         return null
       }
-
-      if (setPhotoFileState) {
-        setPhotoFileState(false)
-      }
-
-      return URL.createObjectURL(file)
+    
+      return { url: URL.createObjectURL(file) }
     })
 
+    registerPhoto(fileInput.files)
     setPreviewUrls((prevPreviewUrls) => [...prevPreviewUrls, ...newPreviewUrls])
   }
 
   const onRemoveImage = (index: number) => {
-    const newPreviewUrls = [...previewUrls]
-    newPreviewUrls.splice(index, 1)
-    setPreviewUrls(newPreviewUrls)
-    removePhoto(index)
+    const deletedPreviewUrl = previewUrls[index]
+    // 
+    if (deletedPreviewUrl?.index && removeExistingPhoto) {
+      removeExistingPhoto(deletedPreviewUrl.index)
+      setphotoInitCount((photoInitCount) => photoInitCount - 1)
+    }
+    else {
+      removeNewPhoto(index - photoInitCount)
+    }
+    setPreviewUrls((prevPreviewUrls) => prevPreviewUrls.filter((_, i) => i !== index))
   }
 
   const openPhotoModal = (index: number) => {
     setCurrentPhotoIndex(index)
     setShowPhotoModal(true)
-  }
-
-  const updateDimensionsForIndex = (index: number, newSize: {width: number, height: number}) => {
-    setDimensions((prevDimensions) => {
-      const updatedDimensions = [...prevDimensions]
-      updatedDimensions[index] = { width: newSize.width, height: newSize.height }
-      return updatedDimensions;
-    })
   }
 
   return (
@@ -117,7 +107,7 @@ export const ImageUploader = <FormData extends FieldValues> ({
           disabled={previewUrls.length >= maxPhotos}
           multiple={multiple}
           id="upload-photo"
-          {...register(id as Path<FormData>, { onChange: (e) => onFileUploadChange(e) })}
+          onChange={(e) => onFileUploadChange(e)}
         />
       </div>
       <div className="d-inline-flex gap-2 flex-wrap align-items-center">
@@ -130,7 +120,7 @@ export const ImageUploader = <FormData extends FieldValues> ({
                     <div className="d-flex justify-content-end">
                       <button
                         type="button"
-                        className="btn btn-light p-2 pb-1"
+                        className="btn btn-light p-2 pb-1 pt-1"
                         onClick={() => onRemoveImage(index)}
                       >
                         <i className="fa-solid fa-circle-xmark smj-action-delete smj-photo-icon-delete"/>
@@ -139,27 +129,20 @@ export const ImageUploader = <FormData extends FieldValues> ({
                   </div>
                   <div className="d-flex justify-content-center align-items-center">
                     <div
-                      className="cursor-pointer"
+                      className="cursor-pointer smj-photo-size"
                       style={{ 
-                        position: 'relative', 
-                        height: dimensions[index] && dimensions[index].height ? dimensions[index].height : 200, 
-                        width: dimensions[index] && dimensions[index].width ? dimensions[index].width : 200 }}
+                        position: 'relative'}}
                     >
                       <Image
                         className="responsive"
+                        style={{objectFit: 'contain'}}
                         alt={`Fotografie ${index + 1}`}
-                        src={url}
+                        src={url.url}
                         fill
+                        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
                         loading="eager"
-                        key={Date.now()}
+                        priority  
                         onClick={() => openPhotoModal(index)}
-                        onLoadingComplete={({ naturalWidth, naturalHeight }) => {
-                          updateDimensionsForIndex(index, calculateDimensions(naturalWidth, naturalHeight, {
-                              maxWidth: widthOfWindow > 750 ? 320 : 220,
-                              maxHeight: widthOfWindow > 750 ? 320 : 220,
-                            })
-                          )
-                        }}
                       />
                     </div>
                   </div>
@@ -170,9 +153,9 @@ export const ImageUploader = <FormData extends FieldValues> ({
         ))}
         {previewUrls.length < maxPhotos && (
           <div className="smj-add-photo-icon border rounded shadow">
-            <label className="cursor-pointer m-4" htmlFor="upload-photo">
+            <label className="cursor-pointer smj-photo-size" htmlFor="upload-photo">
               <svg
-                className="photo-default"
+                className="m-4"
                 viewBox="-64 -64 128 128"
                 xmlns="http://www.w3.org/2000/svg"
                 strokeWidth="6"
@@ -188,8 +171,7 @@ export const ImageUploader = <FormData extends FieldValues> ({
       
       {showPhotoModal && currentPhotoIndex !== null && previewUrls[currentPhotoIndex] && (
         <PhotoModal
-          widthOfWindow={widthOfWindow}
-          photo={previewUrls[currentPhotoIndex] as string}
+          photo={previewUrls[currentPhotoIndex]?.url as string}
           onClose={() => setShowPhotoModal(false)}
         />
       )}

--- a/web/lib/components/jobs/CreateProposedJobForm.tsx
+++ b/web/lib/components/jobs/CreateProposedJobForm.tsx
@@ -44,6 +44,7 @@ export default function CreateProposedJobForm({
     handleSubmit,
     formState: { errors },
     setValue,
+    getValues,
   } = useForm<ProposedJobCreateData>({
     resolver: zodResolver(ProposedJobCreateSchema),
     defaultValues: {
@@ -95,9 +96,45 @@ export default function CreateProposedJobForm({
     }
   }
 
-  const removePhoto = (id: number) => {
-    console.log("remove")
+  
+  //#region Photo
+
+
+  // Remove newly added photo from FileList before sending
+  const removeNewPhoto = (index: number) => {
+    const prevPhotoFiles = getValues('photoFiles')
+    const dt = new DataTransfer()
+
+    // Add only those photos that are not on index
+    for (let i = 0; i < prevPhotoFiles.length; i++) {
+      const file = prevPhotoFiles[i]
+      if (index !== i)
+        dt.items.add(file)
+    }
+    setValue('photoFiles', dt.files)
   }
+
+  // Register newly added photo to FileList
+  const registerPhoto = (fileList: FileList) => {
+    const prevPhotoFiles = getValues('photoFiles')
+    const dt = new DataTransfer()
+
+    // Add existing files to data transfer
+    for (let i = 0; i < prevPhotoFiles?.length; i++) {
+      const file = prevPhotoFiles[i];
+      dt.items.add(file);
+    }
+
+    // Add newly added files to data transfer
+    for (let i = 0; i < fileList.length; i++) {
+      const file = fileList[i];
+      dt.items.add(file);
+    }
+
+    setValue('photoFiles', dt.files)
+  }
+
+  //#endregion
 
   return (
     <>
@@ -158,8 +195,8 @@ export default function CreateProposedJobForm({
               label="Fotografie"
               secondaryLabel="Maximálně 10 souborů, každý o maximální velikosti 10 MB."
               errors={errors}
-              register={register}
-              removePhoto={removePhoto}
+              registerPhoto={registerPhoto}
+              removeNewPhoto={removeNewPhoto}
               multiple
               maxPhotos={10}
             />

--- a/web/lib/components/jobs/CreateProposedJobForm.tsx
+++ b/web/lib/components/jobs/CreateProposedJobForm.tsx
@@ -99,38 +99,25 @@ export default function CreateProposedJobForm({
   
   //#region Photo
 
-
   // Remove newly added photo from FileList before sending
   const removeNewPhoto = (index: number) => {
-    const prevPhotoFiles = getValues('photoFiles')
+    const prevPhotoFiles: (FileList | undefined) = getValues('photoFiles')
+    // Filter out the file at the specified index
+    const filteredFiles: Array<File> = Array.from(prevPhotoFiles ?? []).filter((_, i) => i !== index)
+    // Transfer those photos back to photoFiles
     const dt = new DataTransfer()
-
-    // Add only those photos that are not on index
-    for (let i = 0; i < prevPhotoFiles.length; i++) {
-      const file = prevPhotoFiles[i]
-      if (index !== i)
-        dt.items.add(file)
-    }
+    filteredFiles.forEach((file: File) => dt.items.add(file))
     setValue('photoFiles', dt.files)
   }
 
   // Register newly added photo to FileList
   const registerPhoto = (fileList: FileList) => {
-    const prevPhotoFiles = getValues('photoFiles')
+    const prevPhotoFiles: (FileList | undefined) = getValues('photoFiles')
+    // Combine existing files and newly added files
+    const combinedFiles: File[] = (Array.from(prevPhotoFiles ?? [])).concat(Array.from(fileList ?? []))
+    // Transfer those photos back to photoFiles
     const dt = new DataTransfer()
-
-    // Add existing files to data transfer
-    for (let i = 0; i < prevPhotoFiles?.length; i++) {
-      const file = prevPhotoFiles[i];
-      dt.items.add(file);
-    }
-
-    // Add newly added files to data transfer
-    for (let i = 0; i < fileList.length; i++) {
-      const file = fileList[i];
-      dt.items.add(file);
-    }
-
+    combinedFiles.forEach((file: File) => dt.items.add(file))
     setValue('photoFiles', dt.files)
   }
 

--- a/web/lib/components/jobs/EditProposedJobForm.tsx
+++ b/web/lib/components/jobs/EditProposedJobForm.tsx
@@ -125,35 +125,23 @@ export default function EditProposedJobForm({
 
   // Remove newly added photo from FileList before sending
   const removeNewPhoto = (index: number) => {
-    const prevPhotoFiles = getValues('photoFiles')
+    const prevPhotoFiles: (FileList | undefined) = getValues('photoFiles')
+    // Filter out the file at the specified index
+    const filteredFiles: Array<File> = Array.from(prevPhotoFiles ?? []).filter((_, i) => i !== index)
+    // Transfer those photos back to photoFiles
     const dt = new DataTransfer()
-
-    // Add only those photos that are not on index
-    for (let i = 0; i < prevPhotoFiles.length; i++) {
-      const file = prevPhotoFiles[i]
-      if (index !== i)
-        dt.items.add(file)
-    }
+    filteredFiles.forEach((file: File) => dt.items.add(file))
     setValue('photoFiles', dt.files)
   }
 
   // Register newly added photo to FileList
   const registerPhoto = (fileList: FileList) => {
-    const prevPhotoFiles = getValues('photoFiles')
+    const prevPhotoFiles: (FileList | undefined) = getValues('photoFiles')
+    // Combine existing files and newly added files
+    const combinedFiles: File[] = (Array.from(prevPhotoFiles ?? [])).concat(Array.from(fileList ?? []))
+    // Transfer those photos back to photoFiles
     const dt = new DataTransfer()
-
-    // Add existing files to data transfer
-    for (let i = 0; i < prevPhotoFiles?.length; i++) {
-      const file = prevPhotoFiles[i];
-      dt.items.add(file);
-    }
-
-    // Add newly added files to data transfer
-    for (let i = 0; i < fileList.length; i++) {
-      const file = fileList[i];
-      dt.items.add(file);
-    }
-
+    combinedFiles.forEach((file: File) => dt.items.add(file))
     setValue('photoFiles', dt.files)
   }
 

--- a/web/lib/components/jobs/EditProposedJobForm.tsx
+++ b/web/lib/components/jobs/EditProposedJobForm.tsx
@@ -211,8 +211,8 @@ export default function EditProposedJobForm({
               photoInit={fetchImages()}
               errors={errors}
               registerPhoto={registerPhoto}
-              removeExistingPhoto={removeExistingPhoto}
               removeNewPhoto={removeNewPhoto}
+              removeExistingPhoto={removeExistingPhoto}
               multiple
               maxPhotos={10}
             />

--- a/web/lib/components/modal/Modal.tsx
+++ b/web/lib/components/modal/Modal.tsx
@@ -15,8 +15,7 @@ export function Modal({ children, title, size, onClose }: ModalProps) {
     <>
       <div className="modal-backdrop fade show"></div>
       <div
-        className={`modal fade show ${size}`}
-        style={{ display: 'block' }}
+        className={`modal fade show ${size} d-block`}
         tabIndex={-1}
       >
         <div className="modal-dialog">

--- a/web/lib/components/modal/PhotoModal.tsx
+++ b/web/lib/components/modal/PhotoModal.tsx
@@ -1,24 +1,33 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Modal, ModalSize } from './Modal'
 import Image from 'next/image'
 import { calculateDimensions } from '../photo/photo'
 
 type PhotoModalProps = {
-  widthOfWindow: number
   onClose: () => void
   photo: string
 }
 
 export default function PhotoModal({
-  widthOfWindow,
   onClose,
   photo
 }: PhotoModalProps) {
 
   const [dimensions, setDimensions] = useState({
-    width: 200,
-    height: 200,
+    width: 800,
+    height: 800,
   });
+
+  const [widthOfWindow, setWidthOfWindow] = useState(0)
+
+  const handleResize = () => setWidthOfWindow(window.innerWidth)
+
+  useEffect(() => {
+    handleResize()
+    window.addEventListener('resize', handleResize)
+    return () => window.removeEventListener('resize', handleResize)
+  }, [])
+
 
   const determineSizeByWidthOfWindow = () => {
     if(widthOfWindow > 1000)
@@ -31,13 +40,17 @@ export default function PhotoModal({
 
   return (
     <Modal size={ModalSize.LARGE} onClose={onClose}>
-      <div className="d-flex justify-content-center">
-        <div style={{position: "relative", height: dimensions.height, width:dimensions.width}}> 
+      <div className="d-flex justify-content-center justify-self-center justify-items-center">
+        <div 
+          style={{position: "relative", height: dimensions.height, width:dimensions.width}}
+        > 
           <Image
             className="responsive"
+            style={{objectFit: 'contain'}}
             alt="Fotografie"
             src={photo}
             fill
+            sizes="100vw"
             loading="eager"
             key={Date.now()}
             onLoadingComplete={({ naturalWidth, naturalHeight }) => {

--- a/web/lib/components/modal/PhotoModal.tsx
+++ b/web/lib/components/modal/PhotoModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import { Modal, ModalSize } from './Modal'
 import Image from 'next/image'
 import { calculateDimensions } from '../photo/photo'
+import Link from 'next/link'
 
 type PhotoModalProps = {
   onClose: () => void
@@ -42,6 +43,7 @@ export default function PhotoModal({
     <Modal size={ModalSize.LARGE} onClose={onClose}>
       <div className="d-flex justify-content-center justify-self-center justify-items-center">
         <div 
+          className="cursor-pointer"
           style={{position: "relative", height: dimensions.height, width:dimensions.width}}
         > 
           <Image
@@ -58,6 +60,11 @@ export default function PhotoModal({
                 maxWidth: determineSizeByWidthOfWindow(), 
                 maxHeight: determineSizeByWidthOfWindow()
               }))
+            }}
+            onMouseDown={(e) => { // open image in new tab with middle or left mouse click
+              if( e.button === 1 || e.button === 0) {
+                window.open(photo)
+              }
             }}
           /> 
         </div>

--- a/web/lib/components/worker/CreateWorker.tsx
+++ b/web/lib/components/worker/CreateWorker.tsx
@@ -65,8 +65,12 @@ export default function CreateWorker({
     router.back()
   }
 
-  const removePhoto = () => {
-    setValue('photoFile', undefined, { shouldDirty: false, shouldValidate: false})
+  const removeNewPhoto = () => {
+    setValue('photoFile', undefined, { shouldDirty: true, shouldValidate: true })
+  }
+
+  const registerPhoto = (fileList: FileList) => {
+    setValue('photoFile', fileList, { shouldDirty: true, shouldValidate: true })
   }
 
   return (
@@ -143,8 +147,8 @@ export default function CreateWorker({
               label="Fotografie"
               secondaryLabel="Maximálně 1 soubor o maximální velikosti 10 MB."
               errors={errors}
-              register={register}
-              removePhoto={removePhoto}
+              registerPhoto={registerPhoto}
+              removeNewPhoto={removeNewPhoto}
             />
 
             {carAccess && (

--- a/web/lib/components/worker/EditWorker.tsx
+++ b/web/lib/components/worker/EditWorker.tsx
@@ -106,14 +106,16 @@ export default function EditWorker({
 
   //#region File
 
-  /* If photo was deleted set it to yes and let it be dirty so it will be picked by pick later on. */
-  const setPhotoFileState = (state: boolean) => {
-    setValue('photoFileRemoved', state, { shouldDirty: state, shouldValidate: state })
+  const removeNewPhoto = () => {
+    setValue('photoFile', undefined, { shouldDirty: true, shouldValidate: true })
   }
- 
-  const removePhoto = () => {
-    setValue('photoFile', undefined, { shouldDirty: false, shouldValidate: false })
-    setPhotoFileState(true)
+
+  const removeExistingPhoto = () => {
+    setValue('photoFileRemoved', true, { shouldDirty: true, shouldValidate: true })
+  }
+
+  const registerPhoto = (fileList: FileList) => {
+    setValue('photoFile', fileList, { shouldDirty: true, shouldValidate: true })
   }
 
   //#endregion
@@ -201,11 +203,11 @@ export default function EditWorker({
                 id="photoFile"
                 label="Fotografie"
                 secondaryLabel="Maximálně 1 soubor o maximální velikosti 10 MB."
-                photoInit={worker.photoPath ? [`/api/workers/${worker.id}/photo`] : null}
-                setPhotoFileState={setPhotoFileState}
+                photoInit={worker.photoPath ? [{url: `/api/workers/${worker.id}/photo`, index: "0"}] : null}
                 errors={errors}
-                register={register}
-                removePhoto={removePhoto}
+                registerPhoto={registerPhoto}
+                removeNewPhoto={removeNewPhoto}
+                removeExistingPhoto={removeExistingPhoto}
               />
             )}
             {(carAccess || isProfilePage) && (

--- a/web/lib/data/proposed-jobs.ts
+++ b/web/lib/data/proposed-jobs.ts
@@ -6,6 +6,7 @@ import {
 } from 'lib/types/proposed-job'
 import { cache_getActiveSummerJobEventId } from './cache'
 import { NoActiveEventError } from './internal-error'
+import { PhotoIdsDataTest } from 'lib/types/photo'
 
 export async function getProposedJobById(
   id: string
@@ -24,6 +25,25 @@ export async function getProposedJobById(
     },
   })
   return job
+}
+
+export async function getProposedJobPhotoIdsById(
+  id: string
+): Promise<PhotoIdsDataTest | null> {
+  const activeEventId = await cache_getActiveSummerJobEventId()
+  if (!activeEventId) {
+    throw new NoActiveEventError()
+  }
+  const proposedJob = await prisma.proposedJob.findUnique({
+    where: {
+      id: id,
+    },
+    select: {
+      photoIds: true,
+    },
+  })
+  
+  return proposedJob
 }
 
 export async function getProposedJobs(): Promise<ProposedJobComplete[]> {

--- a/web/lib/fetcher/fetcher.ts
+++ b/web/lib/fetcher/fetcher.ts
@@ -36,6 +36,7 @@ const sendData =
     
     // JSON.stringify(arg) could be used here, but among arg can be file or blob too, so we want to avoid those keys
     formData.append('jsonData', jsonData)
+    console.log(formData)
 
     const res = await fetch(url, {
       method: method,

--- a/web/lib/fetcher/fetcher.ts
+++ b/web/lib/fetcher/fetcher.ts
@@ -36,7 +36,6 @@ const sendData =
     
     // JSON.stringify(arg) could be used here, but among arg can be file or blob too, so we want to avoid those keys
     formData.append('jsonData', jsonData)
-    console.log(formData)
 
     const res = await fetch(url, {
       method: method,

--- a/web/lib/types/photo.ts
+++ b/web/lib/types/photo.ts
@@ -10,9 +10,14 @@ export const PhotoPathSchema = z.object({
 
 export type PhotoPathData = z.infer<typeof PhotoPathSchema>
 
-
 export const PhotoPathSchemaTest = z.object({
   photoPath: z.string()
 }).strict()
 
 export type PhotoPathDataTest = z.infer<typeof PhotoPathSchemaTest>
+
+export const PhotoIdsSchemaTest = z.object({
+  photoIds: z.array(z.string())
+}).strict()
+
+export type PhotoIdsDataTest = z.infer<typeof PhotoIdsSchemaTest>

--- a/web/lib/types/proposed-job.ts
+++ b/web/lib/types/proposed-job.ts
@@ -75,8 +75,8 @@ export const ProposedJobCreateSchema = z
       })
       .openapi({ type: 'array', items: { type: 'string', format: 'binary' }})
       .optional(),
-    photoIds: z.array(z.string()),
-    photoIdsDeleted: z.array(z.string()),
+    photoIds: z.array(z.string()).optional(),
+    photoIdsDeleted: z.array(z.string()).optional(),
     availability: z
       .array(z.date().or(z.string().min(1).pipe(z.coerce.date())))
       .openapi({

--- a/web/pages/api/proposed-jobs/[id]/index.ts
+++ b/web/pages/api/proposed-jobs/[id]/index.ts
@@ -1,13 +1,14 @@
 import { APIAccessController } from 'lib/api/APIAccessControler'
 import { APIMethodHandler } from 'lib/api/MethodHandler'
-import { getUploadDirForImages, renameFile, updatePhotoPathByNewFilename } from 'lib/api/fileManager'
+import { deleteFile, getUploadDirForImages, renameFile, updatePhotoPathByNewFilename } from 'lib/api/fileManager'
 import { getPhotoPath, parseForm, parseFormWithImages } from 'lib/api/parse-form'
 import { registerPhotos } from 'lib/api/registerPhotos'
 import { validateOrSendError } from 'lib/api/validator'
-import { createPhoto, updatePhoto } from 'lib/data/photo'
+import { createPhoto, deletePhoto, getPhotoById, updatePhoto } from 'lib/data/photo'
 import {
   deleteProposedJob,
   getProposedJobById,
+  getProposedJobPhotoIdsById,
   updateProposedJob,
 } from 'lib/data/proposed-jobs'
 import logger from 'lib/logger/logger'
@@ -41,7 +42,12 @@ async function patch(
   session: ExtendedSession
 ) {
   const id = req.query.id as string
-  const { files, json } = await parseFormWithImages(req, id, getUploadDirForImages() + `/proposed-job/${id}`, 10)
+  
+  // Get current photoIds
+  const currentPhotoIds = await getProposedJobPhotoIdsById(id)
+  const currentPhotoCnt = currentPhotoIds?.photoIds.length ?? 0
+
+  const { files, json } = await parseFormWithImages(req, id, getUploadDirForImages() + `/proposed-job/${id}`, 10 - currentPhotoCnt)
   const proposedJobData = validateOrSendError(
     ProposedJobUpdateSchema,
     json,
@@ -51,36 +57,33 @@ async function patch(
     return
   }
 
-  /*
-  // Go through every file in files
-  const fileFieldNames = Object.keys(files)
-  fileFieldNames.forEach(async fieldName => { 
-    const file = files[fieldName]
-    const photoPath = getPhotoPath(file)
-    const photo = validateOrSendError(PhotoPathSchemaTest, {photoPath: photoPath}, res)
-    if(!photo) {
-      return
+  // Save existing ids
+  proposedJobData.photoIds = currentPhotoIds?.photoIds ?? []
+
+  // Delete those photos by their ids, that are flaged to be deleted.
+  if(proposedJobData.photoIdsDeleted) {
+    for (const photoId of proposedJobData.photoIdsDeleted) {
+      const photo = await getPhotoById(photoId)
+      if(photo) {
+        deleteFile(photo.photoPath)
+        await deletePhoto(photoId)
+        proposedJobData.photoIds = proposedJobData.photoIds?.filter((id) => id !== photoId)
+      }
     }
-    // create new photo
-    const newPhoto = await createPhoto(photo)
-    // save its id to photoIds array for proposedJob
-    if(!proposedJobData.photoIds) {
-      proposedJobData.photoIds = [newPhoto.id]
-    }
-    else {
-      proposedJobData.photoIds.push(newPhoto.id)
-    }
-    // rename photo to its id instead of temporary name which was proposedJob.id-number given in parseFormWithImages
-    const newPhotoPath = updatePhotoPathByNewFilename(photoPath, newPhoto.id) ?? ''
-    renameFile(photoPath, newPhotoPath)
-    await updatePhoto(newPhoto.id, {photoPath: newPhotoPath})
-  })
-  */
+  }
+
+  // Save photo ids that belong to proposedJob
   const newPhotoIds = await registerPhotos(files)
-  proposedJobData.photoIds ? proposedJobData.photoIds.concat(newPhotoIds) : proposedJobData.photoIds = newPhotoIds
+  if(proposedJobData.photoIds) {
+    proposedJobData.photoIds = proposedJobData.photoIds.concat(newPhotoIds)
+  }
+  else {
+    proposedJobData.photoIds = newPhotoIds
+  }
 
   await logger.apiRequest(APILogEvent.JOB_MODIFY, id, proposedJobData, session)
-  await updateProposedJob(id, proposedJobData)
+  const {photoIdsDeleted, ...rest} = proposedJobData
+  await updateProposedJob(id, rest)
   res.status(204).end()
 }
 

--- a/web/pages/api/proposed-jobs/[id]/photos/[photoId]/index.ts
+++ b/web/pages/api/proposed-jobs/[id]/photos/[photoId]/index.ts
@@ -17,7 +17,7 @@ const get = async (
   if (!allowed) {
     return
   }
-
+  
   const photo = await getPhotoById(photoId)
   if (!photo || !photo.photoPath) {
     res.status(404).end()

--- a/web/pages/api/proposed-jobs/index.ts
+++ b/web/pages/api/proposed-jobs/index.ts
@@ -58,10 +58,10 @@ async function post(
   const job = await createProposedJob(result)
 
   // Create directory for photos
-  await createDirectory(uploadDirectory + "/" + job.id)
+  await createDirectory(uploadDirectory + `/${job.id}`)
 
   // Save those photos and save photo ids that belong to proposedJob
-  const newPhotoIds = await registerPhotos(files, "/" + job.id)
+  const newPhotoIds = await registerPhotos(files, `/${job.id}`)
 
   await updateProposedJob(job.id, {photoIds: newPhotoIds})
   await logger.apiRequest(

--- a/web/styles/custom.css
+++ b/web/styles/custom.css
@@ -530,25 +530,27 @@ img.smj-nav-logo {
   font-size: 24px;
 }
 
-.photo-default {
-  width: 200px;
-  height: 200px;
-}
-
-
 .smj-add-photo-icon:hover {
   background-color: #e9ecef;
+}
+
+.smj-photo-size {
+  height: 200px;
+  width: 200px;
+}
+
+@media (max-width: 768px) {
+  .smj-photo-size {
+    height: 100px;
+    width: 100px;
+  }
+  .smj-photo-icon-delete {
+    font-size: 16px;
+  }
 }
 
 .smj-file-upload {
   opacity: 0;
   position: absolute;
   z-index: -1;
-}
-
-@media (max-width: 390px) {
-  .photo-default {
-    width: 130px;
-    height: 130px;
-  }
 }


### PR DESCRIPTION
Důležitá poznámka je ta, že se podpora pro nahrávání fotografií postupně rozrůstala. Začalo se u nahrávání jediné fotografie pro workera a postupně se řešení rozšířilo i na podporu více fotografií pro proposed-job. V rámci změn se změnily zod schémata, kde soubory s obrázky se přenáší jako FIleList oproti původnímu řešení jako File. Také proběhla revize frontendového nahrávání v souboru ImageUploader, aby se fotografie správně nahrávaly/registrovaly a fungovala podpora mazání pro již existující fotografie tak i ty nové.
U proposed job se liší pojmenování fotografií, které jsou uloženy jako ostatní-složky/proposed-job/proposed-job-id/photo-id.koncovka. Tedy proposed job si drží pole id jednotlivých fotografií odkazujícího do nového schématu/tabulky Photo. U workera se zůstalo u původního řešení: fotografie se ukládají jako  ostatní-složky/workers/worker-id.koncovka a tedy se neodkazují do jiného schématu podle photo-id. Worker si cestu k souboru pamatuje na svém schématu. Tahle skutečnost bude možná v budoucnu potřeba adresovat a sjednotit způsob ukládání. Pro nynější účely však stačí.